### PR TITLE
Display changes

### DIFF
--- a/app/src/main/java/net/tensory/rxjavatalk/DashboardActivity.java
+++ b/app/src/main/java/net/tensory/rxjavatalk/DashboardActivity.java
@@ -20,7 +20,7 @@ public class DashboardActivity extends AppCompatActivity {
         final FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
 
         fragmentTransaction.replace(R.id.house_stark, createHouseFragment(House.STARK));
-        fragmentTransaction.replace(R.id.house_targaryn, createHouseFragment(House.TARGARYEN));
+        fragmentTransaction.replace(R.id.house_targaryen, createHouseFragment(House.TARGARYEN));
         fragmentTransaction.replace(R.id.house_lannister, createHouseFragment(House.LANNISTER));
         fragmentTransaction.replace(R.id.house_night_king, createHouseFragment(House.NIGHT_KING));
 

--- a/app/src/main/java/net/tensory/rxjavatalk/data/BattleFrontFeed.java
+++ b/app/src/main/java/net/tensory/rxjavatalk/data/BattleFrontFeed.java
@@ -16,6 +16,7 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
 public class BattleFrontFeed {
+    private static final int EMIT_RATE_SECONDS = 10;
 
     public enum Front {
         NORTHERN,
@@ -29,11 +30,11 @@ public class BattleFrontFeed {
     public BattleFrontFeed(Front front, DragonManager dragonManager) {
         this.dragonManager = dragonManager;
 
-        Observable<Battle> observable = Observable.interval(10, TimeUnit.SECONDS)
+        Observable<Battle> observable = Observable.interval(EMIT_RATE_SECONDS, TimeUnit.SECONDS)
                 .map(timeInterval -> new Battle(front, generateBattleResults()));
 
         if (front == Front.SOUTHERN) {
-            observable = observable.delay(5, TimeUnit.SECONDS);
+            observable = observable.delay(EMIT_RATE_SECONDS / 2, TimeUnit.SECONDS);
         }
 
         observable.subscribe(battle -> battleSubject.onNext(battle));

--- a/app/src/main/java/net/tensory/rxjavatalk/house/HouseFragment.java
+++ b/app/src/main/java/net/tensory/rxjavatalk/house/HouseFragment.java
@@ -27,6 +27,7 @@ import io.reactivex.disposables.Disposable;
 public class HouseFragment extends Fragment {
 
     public static final String ARG_HOUSE = "ARG_HOUSE";
+    private static final long ANIMATION_DURATION = 2000L;
 
     private HousePresenter presenter;
     private Disposable disposable;
@@ -111,7 +112,7 @@ public class HouseFragment extends Fragment {
         final int defaultTextColor = getResources().getColor(android.R.color.primary_text_light, null);
 
         final ObjectAnimator animator = ObjectAnimator.ofInt(textView, "textColor", Color.RED, defaultTextColor);
-        animator.setDuration(8000L);
+        animator.setDuration(ANIMATION_DURATION);
         animator.setEvaluator(new ArgbEvaluator());
         animator.setInterpolator(new AccelerateInterpolator());
         animator.start();

--- a/app/src/main/res/layout/dashboard_activity.xml
+++ b/app/src/main/res/layout/dashboard_activity.xml
@@ -8,10 +8,8 @@
         android:id="@+id/house_stark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="48dp"
+        app:layout_constraintHorizontal_weight="1"
+        app:layout_constraintVertical_weight="1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -19,21 +17,17 @@
         android:id="@+id/house_lannister"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="48dp"
+        app:layout_constraintHorizontal_weight="1"
+        app:layout_constraintVertical_weight="1"
         app:layout_constraintStart_toEndOf="@id/house_stark"
         app:layout_constraintTop_toTopOf="parent" />
 
     <FrameLayout
-        android:id="@+id/house_targaryn"
+        android:id="@+id/house_targaryen"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="48dp"
+        app:layout_constraintHorizontal_weight="1"
+        app:layout_constraintVertical_weight="1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/house_stark" />
 
@@ -41,10 +35,8 @@
         android:id="@+id/house_night_king"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="48dp"
+        app:layout_constraintHorizontal_weight="1"
+        app:layout_constraintVertical_weight="1"
         app:layout_constraintStart_toEndOf="@id/house_stark"
         app:layout_constraintTop_toBottomOf="@id/house_lannister" />
 


### PR DESCRIPTION
I made a few changes on a local branch to solve minor problems on my end. I'd like to commit them if you're OK with them, but I didn't want to sneak 'em in as riders on another branch.

- Changed spelling for a resource name.
- Pulled animation duration and event emit rates to class constants for easy local tweaking.
- Shortened battle update animation duration back down to 2000ms. I was finding that the longer animation seems to create the perception that 3 houses were involved in one battle update.
- The emulator that I have set up is a Nexus 7 tablet in horizontal mode. (Should I have used a 10" tablet?) With fixed dp margins, the house grid elements get partly cut off the screen. I set layout weights so that the 4 houses divide the space as a 2x2 grid.

Totally OK with not merging these changes if they mess things up from your perspective!
